### PR TITLE
fix: list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -34,6 +34,11 @@ If a task name is provided, it shows only that specific task.`,
 			return fmt.Errorf("no tasks found: %w", err)
 		}
 
+		if len(tasks) == 0 {
+			fmt.Println("no tasks")
+			return nil
+		}
+
 		filteredTasks := filterTasks(tasks, args)
 
 		if len(filteredTasks) == 0 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -42,7 +42,8 @@ If a task name is provided, it shows only that specific task.`,
 		filteredTasks := filterTasks(tasks, args)
 
 		if len(filteredTasks) == 0 {
-			return fmt.Errorf("no tasks found matching: %w", err)
+			fmt.Printf("no tasks found matching %s\n", args[0])
+			return nil
 		}
 
 		displayTasksTable(filteredTasks)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -42,7 +42,7 @@ If a task name is provided, it shows only that specific task.`,
 		filteredTasks := filterTasks(tasks, args)
 
 		if len(filteredTasks) == 0 {
-			fmt.Printf("no tasks found matching %s\n", args[0])
+			fmt.Printf("no tasks found matching \"%s\"\n", args[0])
 			return nil
 		}
 


### PR DESCRIPTION
Resolves #9 

## Changes

- Show message when there are 0 tasks
- Show correct message when there are 0 tasks that match the filter

## Testing

### Zero Tasks
- [ ] Initialize with new empty `tasks.json`
- [ ] Run `go run main.go list`
- [ ] Verify `no tasks` is shown (instead of previous confusing error message)

### No Matches
- [ ] Run with a few tasks
- [ ] Run `go run main.go list zzz`
- [ ] Verify `no tasks found matching "zzz"` is shown (instead of previous incorrect error message)